### PR TITLE
一些細節上的修復

### DIFF
--- a/td_pinyin_flypy.schema.yaml
+++ b/td_pinyin_flypy.schema.yaml
@@ -95,6 +95,7 @@ speller:
 translator:
   dictionary: terra_pinyin
   prism: td_pinyin_flypy
+  spelling_hints: 8
   preedit_format:
     - xform/([bpmfdtnljqx])n/$1iao/
     - xform/(\w)g/$1eng/
@@ -109,6 +110,7 @@ translator:
     - xform/(\w)s/$1ong/
     - xform/(\w)d/$1ai/
     - xform/(\w)f/$1en/
+    - xform/[e]h/ê/
     - xform/(\w)h/$1ang/
     - xform/(\w)j/$1an/
     - xform/([gkhvuirzcs])k/$1uai/
@@ -129,9 +131,12 @@ translator:
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
-    - xform/eh/ê/
     - 'xform ([aeiou])(ng?|r)([-;/<,>\\]) $1$3$2'
-    - 'xform ([aeo])([iuo])([-;/<,>\\]) $1$3$2'
+    # - 'xform ([aeo])([iuo])([-;/<,>\\]) $1$3$2'
+    - 'xform ([o])([o])([-;/<,>\\]) $2$1$3'
+    - 'xform ([a])([io])([-;/<,>\\]) $1$3$2'
+    - 'xform ([e])([i])([-;/<,>\\]) $1$3$2'
+    - 'xform ([o])([u])([-;/<,>\\]) $1$3$2'
     - 'xform a[-;] ā'
     - 'xform a/ á'
     - 'xform a[<,] ǎ'
@@ -144,6 +149,23 @@ translator:
     - 'xform o/ ó'
     - 'xform o[<,] ǒ'
     - 'xform o[>\\] ò'
+    # 下述代碼爲aa撰寫爲a的改良方案，但會降低打字容錯率。
+    # - 'xform (o)(u)([-;/<,>\\]) $1$3$2'
+    # - 'xform a?a[-;] ā'
+    # - 'xform a?a/ á'
+    # - 'xform a?a[<,] ǎ'
+    # - 'xform a?a[>\\] à'
+    # - 'xform a?a a'
+    # - 'xform e?e[-;] ē'
+    # - 'xform e?e/ é'
+    # - 'xform e?e[<,] ě'
+    # - 'xform e?e[>\\] è'
+    # - 'xform e?e e'
+    # - 'xform o?o[-;] ō'
+    # - 'xform o?o/ ó'
+    # - 'xform o?o[<,] ǒ'
+    # - 'xform o?o[>\\] ò'
+    # - 'xform o?o o'
     - 'xform i[-;] ī'
     - 'xform i/ í'
     - 'xform i[<,] ǐ'
@@ -158,7 +180,11 @@ translator:
     - 'xform ü[>\\] ǜ'
   comment_format:
     - xform ([aeiou])(ng?|r)([1234]) $1$3$2
-    - xform ([aeo])([iuo])([1234]) $1$3$2
+    # - xform ([aeo])([iuo])([1234]) $1$3$2
+    - xform ([o])([o])([1234]) $2$1$3
+    - xform ([a])([io])([1234]) $1$3$2
+    - xform ([e])([i])([1234]) $1$3$2
+    - xform ([o])([u])([1234]) $1$3$2
     - xform a1 ā
     - xform a2 á
     - xform a3 ǎ
@@ -187,16 +213,16 @@ translator:
     - xform/eh[0-5]?/ê/
     - xform/([a-z]+)[0-5]/$1/
 
-reverse_lookup:
-  dictionary: stroke
-  enable_completion: true
-  prefix: "`"
-  suffix: "'"
-  tips: 〔筆畫〕
-  preedit_format:
-    - xlit/hspnz/一丨丿丶乙/
-  comment_format:
-    - xform/([nl])v/$1ü/
+# reverse_lookup:
+  # dictionary: stroke
+  # enable_completion: true
+  # prefix: "`"
+  # suffix: "'"
+  # tips: 〔筆畫〕
+  # preedit_format:
+    # - xlit/hspnz/一丨丿丶乙/
+  # comment_format:
+    # - xform/([nl])v/$1ü/
 
 punctuator:
   import_preset: default


### PR DESCRIPTION
- 將`eh`的輸入轉錄成了`ê`而不是`eang`，更符合漢語拼音規範。
- 將帶聲調的`aa ee oo`之聲調符號都放在後面一個韻母上，增強了美觀性，例如`aā eē oō`。修復之前，`oō`的顯示情況是`ōo`，不統一。代碼註釋裡有將兩個聲母合成一個字母的方案，但考慮到容易降低打字的容錯率，故沒有得以使用。
- 在後選字後面添加了拼音補全，這一個功能是借鑑了粵拼的代碼來實現的。
- 廢除了（註釋化）筆劃反查功能——既然是要搞帶調雙拼，就要搞最純淨的帶調雙拼，不要弄一些花藜胡哨的東西。同時我也發現了這個功能會與我「候選字後拼音補全」的功能起衝突。